### PR TITLE
added comment to height parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For a full list of options available, please refer to fullcalendar.io documentat
 })
 export class MyComponent{
     calendarOptions:Object = {
-        height: 'parent',
+        height: 'parent', // if you're parent object doesn't have a height specified, remove this property
         fixedWeekCount : false,
         defaultDate: '2016-09-12',
         editable: true,


### PR DESCRIPTION
Added comment to `height: 'parent'` property on `calendarOptions` to mention that in order for that to work the parent needs to have a height style on it. If it doesn't, remove this property.